### PR TITLE
Custom tags for saved pocket links

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -12,7 +12,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>DF3A17F0-109C-498C-953A-1EA26ABBE2E2</string>
+				<string>61BAF2DE-E59C-44AD-BF83-22B2162B8331</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -68,6 +68,17 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>94B5A64D-BE8D-43B8-847A-F84CA4214C44</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+			</dict>
+		</array>
+		<key>61BAF2DE-E59C-44AD-BF83-22B2162B8331</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>DF3A17F0-109C-498C-953A-1EA26ABBE2E2</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -373,7 +384,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>python pocket_save.py</string>
+				<string>python pocket_save.py {query}</string>
 				<key>type</key>
 				<integer>0</integer>
 			</dict>
@@ -411,6 +422,27 @@
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>keyword</key>
+				<string>pocket add</string>
+				<key>subtext</key>
+				<string>Add Safari/Chrome page to Pocket with additional tags</string>
+				<key>text</key>
+				<string>Add To Pocket</string>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>61BAF2DE-E59C-44AD-BF83-22B2162B8331</string>
+			<key>version</key>
+			<integer>0</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string></string>
@@ -445,6 +477,11 @@
 		<dict>
 			<key>ypos</key>
 			<real>230</real>
+		</dict>
+		<key>61BAF2DE-E59C-44AD-BF83-22B2162B8331</key>
+		<dict>
+			<key>ypos</key>
+			<real>680</real>
 		</dict>
 		<key>739C48C5-6C99-4B62-AAB4-E23DCD2035B5</key>
 		<dict>

--- a/src/pocket_save.py
+++ b/src/pocket_save.py
@@ -10,7 +10,7 @@ def main(wf):
     current_app = os.popen(
         """ osascript -e 'application (path to frontmost application as text)' """).readline().rstrip()
     if current_app in ['Google Chrome', 'Safari']:
-        if not add_item(get_browser_item(current_app)):
+        if not add_item(get_browser_item(current_app, wf.args)):
             print "%s link invalid." % current_app
             return 0
         print "%s link added to Pocket." % current_app
@@ -63,13 +63,13 @@ def get_clipboard_item():
     }
 
 
-def add_item(item):
+def add_item(item, tags):
     if item is not None:
         access_token = wf.get_password('pocket_access_token')
         pocket_instance = Pocket(config.CONSUMER_KEY, access_token)
         try:
             pocket_instance.add(
-                url=item['url'], title=item['title'], tags="alfred")
+                url=item['url'], title=item['title'], tags=",".join(["alfred"] + tags))
             return True
         except InvalidQueryException:
             pass


### PR DESCRIPTION
Hi!
I've added an additional keyword trigger to manually add custom tags for saved links.
Here is an example:
`pocket add myTag1 myTag2`

I hope you like it.

Cheers,
Andreas