### PR TITLE
Updating the new URL scheme on getpocket.com

### DIFF
--- a/src/pocket_launcher.py
+++ b/src/pocket_launcher.py
@@ -8,7 +8,7 @@ from workflow import Workflow
 import config
 
 WF = Workflow()
-POCKET_URL = 'http://getpocket.com/a/read/%s'
+POCKET_URL = 'https://app.getpocket.com/read/%s'
 
 
 def execute():


### PR DESCRIPTION
Fixed a bug which opens getpocket.com homepage instead of the article. 

@fniephaus 